### PR TITLE
Add ZSH framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-prettyping
-==========
+# prettyping
 
 [Donation - buy me a coffee](https://denilson.sa.nom.br/donate.html)
 
@@ -17,8 +16,7 @@ versions of `awk` (`gawk`, `mawk`, `nawk`, `busybox awk`).
 Read about the history of this project, as well as detailed information,
 screenshots, videos at: <http://denilsonsa.github.io/prettyping/>
 
-Requirements
-------------
+## Requirements
 
 * `bash` (tested on 4.20, should work on versions as old as 2008)
 * `awk` (either `gawk`, `mawk`, `nawk` or `busybox awk`; should work on `gawk`
@@ -28,8 +26,9 @@ Requirements
    output, like Mac OS X ping or [oping][])
 * Optional dependency on `stty` or `tput` to auto-detect the terminal size.
 
-Installation
-------------
+## Installation
+
+### Manual
 
 1. Download [prettyping][] script and save it anywhere.
 2. Make it executable: `chmod +x prettyping`
@@ -38,11 +37,28 @@ That's all! No root permission is required. You can save and run it from any
 directory. As long as your user can run `ping`, `bash` and `awk`, then
 `prettyping` will work.
 
+### GitHub
+
 Alternatively, you can download the latest tarball from GitHub: [![Latest release](https://img.shields.io/github/release/denilsonsa/prettyping.svg)](https://github.com/denilsonsa/prettyping/releases/latest)
 
-For people building a `prettyping` package (for any Linux distro or for Mac OS
-X), just install the `prettyping` script into `/usr/bin/`, or whatever
+For people building a `prettyping` package (for any Linux distro or for Mac OS X), just install the `prettyping` script into `/usr/bin/`, or whatever
 directory is appropriate. No other file is necessary.
+
+### ZSH Frameworks
+
+#### Zgenom
+
+If you're using [Zgenom](https://github.com/jandamm/zgenom):
+
+1. Add `zgenom load unixorn/prettyping` to your `.zshrc` along with your other `zgenom load` commands.
+2. `zgenom reset && zgenom save`
+
+#### Antigen
+
+If you're using [Antigen](https://github.com/zsh-users/antigen):
+
+1. Add `antigen bundle unixorn/prettyping` to your `.zshrc` where you've listed your other plugins.
+2. Close and reopen your Terminal/iTerm window to **refresh context** and use the plugin. Alternatively, you can run `antigen bundle unixorn/prettyping` in a running shell to have `antigen` load the new plugin.
 
 [oping]: http://verplant.org/liboping/
 [prettyping]: https://raw.githubusercontent.com/denilsonsa/prettyping/master/prettyping

--- a/prettyping.plugin.zsh
+++ b/prettyping.plugin.zsh
@@ -1,0 +1,18 @@
+# Copyright 2022 Joseph Block <jpb@unixorn.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Add our plugin's bin diretory to user's path
+PLUGIN_BIN="$(dirname $0)"
+export PATH=${PATH}:${PLUGIN_BIN}


### PR DESCRIPTION
- Add `prettyping.plugin.zsh` for ZSH framework support
- Add `zgenom` and `antigen` instructions

Signed-off-by: Joe Block <jpb@unixorn.net>